### PR TITLE
limit number of available GPUs

### DIFF
--- a/src/main/scala/BIDMat/GMat.scala
+++ b/src/main/scala/BIDMat/GMat.scala
@@ -1859,28 +1859,28 @@ object GMat {
 
   }
   
-  def setGPU(i:Int) = jcuda.runtime.JCuda.cudaSetDevice(i)
+  def setGPU(i:Int) = jcuda.runtime.JCuda.cudaSetDevice(Mat.cudaDeviceIndexMap(i))
   
   def getGPU:Int = {
     val ar = Array[Int](1)
     jcuda.runtime.JCuda.cudaGetDevice(ar)
-    ar(0)
+    Mat.cudaDeviceInverseIndexMap(ar(0))
   }
   
   def connect(i:Int) = {
-    val v0 = jcuda.runtime.JCuda.cudaDeviceEnablePeerAccess(i,0)
+    val v0 = jcuda.runtime.JCuda.cudaDeviceEnablePeerAccess(Mat.cudaDeviceIndexMap(i),0)
     val j = getGPU
     setGPU(i)
-    val v1 = jcuda.runtime.JCuda.cudaDeviceEnablePeerAccess(j,0)
+    val v1 = jcuda.runtime.JCuda.cudaDeviceEnablePeerAccess(Mat.cudaDeviceInverseIndexMap(j),0)
     setGPU(j)
     (v0, v1)
   }
   
   def disconnect(i:Int) = {
-    val v0 = jcuda.runtime.JCuda.cudaDeviceDisablePeerAccess(i)
+    val v0 = jcuda.runtime.JCuda.cudaDeviceDisablePeerAccess(Mat.cudaDeviceIndexMap(i))
     val j = getGPU
     setGPU(i)
-    val v1 = jcuda.runtime.JCuda.cudaDeviceDisablePeerAccess(j)
+    val v1 = jcuda.runtime.JCuda.cudaDeviceDisablePeerAccess(Mat.cudaDeviceInverseIndexMap(j))
     setGPU(j)
     (v0, v1)
   }
@@ -1888,9 +1888,11 @@ object GMat {
   def canconnect(i:Int) = {
     val ar = Array[Int](1)
     val j = getGPU
-    jcuda.runtime.JCuda.cudaDeviceCanAccessPeer(ar, i, j)
-    val v0 = ar(0) 
-    jcuda.runtime.JCuda.cudaDeviceCanAccessPeer(ar, j, i)
+    val mi: Int = Mat.cudaDeviceIndexMap(i)
+    val mj: Int = Mat.cudaDeviceIndexMap(j)
+    jcuda.runtime.JCuda.cudaDeviceCanAccessPeer(ar, mi, mj)
+    val v0 = ar(0)
+    jcuda.runtime.JCuda.cudaDeviceCanAccessPeer(ar, mj, mi)
     (v0, ar(0))
   }
   


### PR DESCRIPTION
This PR limits the number of GPUs available to BIDMat.

It solves the following issue. In a shared environment (grid, cloud, etc), the grid admin may grant a user a number of GPUs for the BIDMat job, however the physical IDs of the available GPUs are not given. The user need to find them first, then limit BIDMat to use those GPUs. 

For example, say there are 8 GPUs (#0~#7) in a node, among them #0, #1, #3 are already used and not available to new jobs. 2 GPUs are granted to a new BIDMat job, but the program has to search for the available GPUs and limit itself to those. In this case, #2 and #4 are a pair available for this job.

Setting CUDA_VISIBLE_DEVICES is not an options since the GPUs are not known a priori.

In this PR, we store (physical device ID <-->  logical device ID) map and convert between the two indices during setGPU and getGPU. In the example above:
  physical device #2 <--> logical device #0 
  physical device #4 <--> logical device #1 


