### PR TITLE
tweaks, fixes, and updates for aarch64 architecture (aka arm64)

### DIFF
--- a/jni/src/BIDMat_LAPACK.c
+++ b/jni/src/BIDMat_LAPACK.c
@@ -1,7 +1,7 @@
 
 #include <jni.h>
 #ifndef __arm__          // Need a working Lapack first
-#ifdef __arm__
+#if defined(__arm__) || defined(__aarch64__)
 #include <lapacke.h>
 #else
 #include <mkl.h>

--- a/jni/src/Makefile
+++ b/jni/src/Makefile
@@ -52,7 +52,9 @@ $(INSTALL_DIR)/$(LIBPREPEND)bidmatcuda$(LIBAPPEND): $(LIBPREPEND)bidmatcuda$(LIB
 
 $(INSTALL_DIR)/$(LIBPREPEND)bidmatcpu$(LIBAPPEND): $(LIBPREPEND)bidmatcpu$(LIBAPPEND) $(INSTALL_DIR)
 	cp $(LIBPREPEND)bidmatcpu$(LIBAPPEND) $(INSTALL_DIR)
-	cp $(LIBDIR)/libiomp5$(LIBIOMPAPPEND) $(INSTALL_DIR)
+	if [ -n "$(findstring liomp5,$(CPU_LIBS))" ]; then \
+		cp $(LIBDIR)/libiomp5$(LIBIOMPAPPEND) $(INSTALL_DIR); \
+	fi
 
 $(INSTALL_DIR):
 	mkdir -p $(INSTALL_DIR)

--- a/jni/src/Sorting.cu
+++ b/jni/src/Sorting.cu
@@ -12,7 +12,6 @@
 #include <thrust/iterator/reverse_iterator.h>
 #include <thrust/device_vector.h>
 #include <thrust/sort.h>
-//#include <cub/device/device_radix_sort.cuh>
 
 #if __CUDA_ARCH__ > 200
 #define MAXXGRID 2147483647

--- a/jni/src/configure
+++ b/jni/src/configure
@@ -42,12 +42,21 @@ elif [ "$ARCH" = "amd64" ] || [ "$ARCH" = "x86_64" ] ; then
     MBITS=64
 elif [[ "$ARCH" == armv7* ]] ; then
     ARCH="arm"
-    ARMARCH="armv7-a"
     MBITS=32
+    ARMFLAGS="-marm -march=armv7-a -mfpu=vfpv3 -mfloat-abi=hard"
 elif [ "$ARCH" = "aarch64" ] ; then
-    ARCH="arm"
-    ARMARCH="armv8-a"
+    ARCH="aarch64"
     MBITS=64
+
+    gcc cpuid_arm64.c -o cpuid_arm64 >/dev/null
+    if [[ $? -ne 0 ]]; then
+        echo 'failed to compile cpuid_arm64, aborting' && exit 1
+    fi
+    if [[ $(./cpuid_arm64) == "CORTEXA57" ]]; then
+        ARMFLAGS="-march=armv8-a+crc+crypto+fp+simd -mtune=cortex-a57"
+    else
+        ARMFLAGS="-march=armv8-a"
+    fi
 else
     echo "ARCH not supported"
     exit 1
@@ -119,19 +128,17 @@ if [ "$OS" = "apple" ] ; then
     INSTALL_DIR="${BIDMAT_ROOT}/src/main/resources/lib"
     CUDA_LIBS="-L${CUDA_HOME}/lib -L${LIBDIR} -lcudart -lcublas"
 elif [ "$OS" = "linux" ] ; then
-    if [ "$ARCH" = "arm" ] ; then
+    if [ "$ARCH" = "arm" ] || [[ "$ARCH" = "aarch64" ]] ; then
 	RANDSRC="RAND"
 	if [ "$QSML_ROOT" != "" ]; then
 	    BLAS_INCLUDE="-I$QSML_ROOT/include"
 	    BLAS_LIB="-L$QSML_ROOT/lib -lQSML -lsymphony-cpu"
+	elif [ "$OPENBLAS_ROOT" != "" ]; then
+	    BLAS_INCLUDE="-I$OPENBLAS_ROOT/include"
+	    BLAS_LIB="-L$OPENBLAS_ROOT/lib -lopenblas"
 	else
-	    if [ "$OPENBLAS_ROOT" != "" ]; then
-		BLAS_INCLUDE="-I$OPENBLAS_ROOT/include"
-		BLAS_LIB="-L$OPENBLAS_ROOT/lib -lopenblas"
-	    else
-		BLAS_INCLUDE="-I/usr/local/include"
-		BLAS_LIB="-L/usr/local/lib -lopenblas"
-	    fi
+	    BLAS_INCLUDE="-I/usr/local/include"
+	    BLAS_LIB="-L/usr/local/lib -lopenblas"
 	fi
 	if [ "$JAVA_HOME" = "" ]; then
 	    JAVA_HOME="/usr/java/default"
@@ -142,14 +149,17 @@ elif [ "$OS" = "linux" ] ; then
 	CC="gcc"
 	GCC="g++"
 	NVCC="nvcc" 
-	NVCCFLAGS="-c -use_fast_math -I$BIDMAT_ROOT/jni/include \
-          --maxrregcount=31 \
-          -gencode arch=compute_32,code=sm_32 \
-          --machine ${MBITS}  -Xcompiler \"-fPIC -c -O2 -g -march=${ARMARCH} -DNDEBUG\""
+	if [ "$ARCH" = "arm" ] ; then
+            NVARCH="-gencode arch=compute_32,code=sm_32"
+	else
+            NVARCH="-gencode arch=compute_53,code=sm_53 \
+                    -gencode arch=compute_53,code=compute_53"
+	fi
+	NVCCFLAGS="-c -use_fast_math -I$BIDMAT_ROOT/jni/include --maxrregcount=31 ${NVARCH} --machine ${MBITS} -Xcompiler \"-fPIC -c -O2 -g ${ARMFLAGS} -DNDEBUG\""
 	OBJ="o"
 	OUTFLG="-o "
-	CPPFLAGS="-fPIC -std=c++11 -marm -mfpu=vfpv3 -mfloat-abi=hard -march=${ARMARCH} -c -O2 -DNDEBUG -I$JAVA_HOME/include -I$JAVA_HOME/include/linux -I$BIDMAT_ROOT/jni/include -I$CUDA_HOME/include ${BLAS_INCLUDE}"
-	CFLAGS="-fPIC -fopenmp -marm -mfpu=vfpv3 -mfloat-abi=hard -march=${ARMARCH} -c -O2 -DNDEBUG -I$JAVA_HOME/include -I$JAVA_HOME/include/linux -I$BIDMAT_ROOT/jni/include ${BLAS_INCLUDE}"
+	CPPFLAGS="-fPIC -std=c++11 ${ARMFLAGS} -c -O2 -DNDEBUG -I$JAVA_HOME/include -I$JAVA_HOME/include/linux -I$BIDMAT_ROOT/jni/include -I$CUDA_HOME/include ${BLAS_INCLUDE}"
+	CFLAGS="-fPIC -fopenmp ${ARMFLAGS} -c -O2 -DNDEBUG -I$JAVA_HOME/include -I$JAVA_HOME/include/linux -I$BIDMAT_ROOT/jni/include ${BLAS_INCLUDE}"
 	LB="ar rc"    
 	GLD="g++ -shared"
 	LD="gcc -shared -z noexecstack"

--- a/jni/src/cpuid_arm64.c
+++ b/jni/src/cpuid_arm64.c
@@ -1,0 +1,244 @@
+/**************************************************************************
+  Copyright (c) 2013, The OpenBLAS Project
+  All rights reserved.
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+  1. Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in
+  the documentation and/or other materials provided with the
+  distribution.
+  3. Neither the name of the OpenBLAS project nor the names of
+  its contributors may be used to endorse or promote products
+  derived from this software without specific prior written permission.
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE OPENBLAS PROJECT OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *****************************************************************************/
+
+#include <stdio.h>
+#include <string.h>
+
+#define CPU_UNKNOWN     	0
+#define CPU_ARMV8       	1
+#define CPU_CORTEXA57       	2
+
+static char *cpuname[] = {
+  "UNKNOWN",
+  "ARMV8" ,
+  "CORTEXA57"
+};
+
+static char *cpuname_lower[] = {
+  "unknown",
+  "armv8" ,
+  "cortexa57"
+};
+
+int get_feature(char *search)
+{
+
+#ifdef linux
+	FILE *infile;
+  	char buffer[2048], *p,*t;
+  	p = (char *) NULL ;
+
+  	infile = fopen("/proc/cpuinfo", "r");
+
+	while (fgets(buffer, sizeof(buffer), infile))
+	{
+
+		if (!strncmp("Features", buffer, 8))
+		{
+			p = strchr(buffer, ':') + 2;
+			break;
+		}
+	}
+
+	fclose(infile);
+
+
+	if( p == NULL ) return 0;
+
+	t = strtok(p," ");
+	while( t = strtok(NULL," "))
+	{
+		if (!strcmp(t, search))   { return(1); }
+	}
+
+#endif
+	return(0);
+}
+
+
+int detect(void)
+{
+
+#ifdef linux
+
+	FILE *infile;
+  	char buffer[512], *p;
+  	p = (char *) NULL ;
+
+  	infile = fopen("/proc/cpuinfo", "r");
+	while (fgets(buffer, sizeof(buffer), infile))
+	{
+
+		if (!strncmp("CPU part", buffer, 8))
+		{
+			p = strchr(buffer, ':') + 2;
+			break;
+		}
+	}
+
+	fclose(infile);
+	if(p != NULL) {
+	  if (strstr(p, "0xd07")) {
+	    return CPU_CORTEXA57;
+	  }
+	}
+
+	p = (char *) NULL ;
+	infile = fopen("/proc/cpuinfo", "r");
+	while (fgets(buffer, sizeof(buffer), infile))
+	{
+
+		if ((!strncmp("model name", buffer, 10)) || (!strncmp("Processor", buffer, 9)) ||
+		    (!strncmp("CPU architecture", buffer, 16)))
+		{
+			p = strchr(buffer, ':') + 2;
+			break;
+      		}
+  	}
+
+  	fclose(infile);
+
+  	if(p != NULL)
+	{
+
+		if (strstr(p, "AArch64"))
+		{
+			return CPU_ARMV8;
+
+		}
+
+
+	}
+#endif
+
+	return CPU_UNKNOWN;
+}
+
+char *get_corename(void)
+{
+	return cpuname[detect()];
+}
+
+void get_architecture(void)
+{
+	printf("ARM64");
+}
+
+void get_subarchitecture(void)
+{
+	int d = detect();
+	printf("%s", cpuname[d]);
+}
+
+void get_subdirname(void)
+{
+	printf("arm64");
+}
+
+void get_cpuconfig(void)
+{
+
+	int d = detect();
+	switch (d)
+	{
+
+		case CPU_ARMV8:
+    			printf("#define ARMV8\n");
+    			printf("#define L1_DATA_SIZE 32768\n");
+    			printf("#define L1_DATA_LINESIZE 64\n");
+    			printf("#define L2_SIZE 262144\n");
+    			printf("#define L2_LINESIZE 64\n");
+    			printf("#define DTB_DEFAULT_ENTRIES 64\n");
+    			printf("#define DTB_SIZE 4096\n");
+    			printf("#define L2_ASSOCIATIVE 4\n");
+			break;
+
+		case CPU_CORTEXA57:
+			printf("#define CORTEXA57\n");
+			printf("#define HAVE_VFP\n");
+			printf("#define HAVE_VFPV3\n");
+			printf("#define HAVE_NEON\n");
+			printf("#define HAVE_VFPV4\n");
+			printf("#define L1_CODE_SIZE 49152\n");
+			printf("#define L1_CODE_LINESIZE 64\n");
+			printf("#define L1_CODE_ASSOCIATIVE 3\n");
+			printf("#define L1_DATA_SIZE 32768\n");
+			printf("#define L1_DATA_LINESIZE 64\n");
+			printf("#define L1_DATA_ASSOCIATIVE 2\n");
+			printf("#define L2_SIZE 2097152\n");
+			printf("#define L2_LINESIZE 64\n");
+			printf("#define L2_ASSOCIATIVE 16\n");
+    			printf("#define DTB_DEFAULT_ENTRIES 64\n");
+    			printf("#define DTB_SIZE 4096\n");
+			break;
+	}
+}
+
+
+void get_libname(void)
+{
+	int d = detect();
+	printf("%s", cpuname_lower[d]);
+}
+
+void get_features(void)
+{
+
+#ifdef linux
+	FILE *infile;
+  	char buffer[2048], *p,*t;
+  	p = (char *) NULL ;
+
+  	infile = fopen("/proc/cpuinfo", "r");
+
+	while (fgets(buffer, sizeof(buffer), infile))
+	{
+
+		if (!strncmp("Features", buffer, 8))
+		{
+			p = strchr(buffer, ':') + 2;
+			break;
+      		}
+  	}
+
+  	fclose(infile);
+
+
+	if( p == NULL ) return;
+
+	t = strtok(p," ");
+	while( t = strtok(NULL," "))
+	{
+	}
+
+#endif
+	return;
+}
+
+void main() {
+	printf("%s", get_corename());
+}

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,19 @@
       </properties>
     </profile>
     <profile>
+      <id>linux_aarch64</id>
+      <activation>
+      	<os>
+          <family>unix</family>
+          <arch>aarch64</arch>
+          <name>!mac os x</name> <!--https://issues.apache.org/jira/browse/MNG-4983-->
+      	</os>
+      </activation>
+      <properties>
+        <osarch>linux-aarch64</osarch>
+      </properties>
+    </profile>
+    <profile>
       <id>gpu</id>
       <activation>
         <property>
@@ -318,6 +331,7 @@
           </execution>
         </executions>
         <configuration>
+          <recompileMode>incremental</recompileMode>
           <jvmArgs>
             <jvmArg>-Xmx12g</jvmArg>
           </jvmArgs>

--- a/src/main/java/edu/berkeley/bid/LibUtils.java
+++ b/src/main/java/edu/berkeley/bid/LibUtils.java
@@ -59,7 +59,7 @@ public final class LibUtils
      */
     public static enum ARCHType
     {
-        PPC, PPC_64, SPARC, X86, X86_64, ARM, MIPS, RISC, UNKNOWN
+        PPC, PPC_64, SPARC, X86, X86_64, ARM, AARCH64, MIPS, RISC, UNKNOWN
     }
     
     /**
@@ -134,7 +134,7 @@ public final class LibUtils
         
         try
         {
-        	if (loadIOMP && arch != ARCHType.ARM) {
+        	if (loadIOMP && !(arch == ARCHType.ARM || arch == ARCHType.AARCH64)) {
           	System.loadLibrary(getIOMPlibName());        		
         	}
         	System.loadLibrary(libName);
@@ -399,9 +399,13 @@ public final class LibUtils
         {
             return ARCHType.SPARC;
         }
-        if (osArch.startsWith("arm") || osArch.startsWith("aarch"))   // For now, arm CUDA libs are still 32bit on 64bit machines
-        {                                                             // this code will split if that changes
+        if (osArch.startsWith("arm"))
+        {
             return ARCHType.ARM;
+        }
+        if (osArch.startsWith("aarch64"))
+        {
+            return ARCHType.AARCH64;
         }
         if (osArch.startsWith("mips"))
         {


### PR DESCRIPTION
BIDMat successfully builds on `aarch64`! Summary of changes:
1. Updated `jni/src/configure` for building native bidmat-cpu/gpu
   - Copied (with attribution) an `aarch64` [feature detection program from OpenBLAS](https://github.com/xianyi/OpenBLAS/blob/develop/cpuid_arm64.c) for generating better compiler flags, MIT Licensed so it should be good to go
2. Added profile for `linux_aarch64` in POM file
   - Also enabled incremental compilation feature of the `scala-maven-plugin`, significantly speed ups compilation
3. Tweaked a few lines of native and Java code to support `aarch64`
